### PR TITLE
Kfp 1.8.22

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ckadner @manuelwalserqc @maximerihouey @ncolomer @nicolas-geniteau @radcheb @tanguycdls @tarrade
+* @ckadner @manuelwalserqc @maximerihouey @ncolomer @nicolas-geniteau @radcheb @tanguycdls @tarrade @alanhdu

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ckadner @manuelwalserqc @maximerihouey @ncolomer @nicolas-geniteau @radcheb @tanguycdls
+* @ckadner @manuelwalserqc @maximerihouey @ncolomer @nicolas-geniteau @radcheb @tanguycdls @tarrade

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About kfp
-=========
+About kfp-feedstock
+===================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/kfp-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/kubeflow/pipelines
 
 Package license: Apache-2.0
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/kfp-feedstock/blob/main/LICENSE.txt)
 
 Summary: Reusable end-to-end ML workflows built using the Kubeflow Pipelines SDK.
 
@@ -161,4 +161,5 @@ Feedstock Maintainers
 * [@nicolas-geniteau](https://github.com/nicolas-geniteau/)
 * [@radcheb](https://github.com/radcheb/)
 * [@tanguycdls](https://github.com/tanguycdls/)
+* [@tarrade](https://github.com/tarrade/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,4 +95,3 @@ extra:
     - manuelwalserqc
     - tarrade
     - alanhdu
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,3 +94,5 @@ extra:
     - ckadner
     - manuelwalserqc
     - tarrade
+    - alanhdu
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,19 +24,18 @@ requirements:
     - pip
   run:
     - python >=3.7
-    - absl-py >=0.9,<=0.11
-    - PyYAML >=5.3,<6
+    - absl-py >=0.9,<2
+    - PyYAML >=5.3,<7
+    # Pin google-api-core version for the bug fixing in 1.31.5
+    # https://github.com/googleapis/python-api-core/releases/tag/v1.31.5
+    - google-api-core >=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
-    - google-cloud-storage >=2.2.1,<3
-    - python-kubernetes >=8.0.0,<19
-    # google-api-python-client v2 doesn't work for private dicovery by default:
+    - google-cloud-storage >=1.20.0,<3
+    - kubernetes >=8.0.0,<26
+    # google-api-python-client v2 doesnt work for private dicovery by default:
     # https://github.com/googleapis/google-api-python-client/issues/1225#issuecomment-791058235
     - google-api-python-client >=1.7.8,<2
-    - google-api-core >=1.31.5,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0dev
-    # NOTE: Maintainers, please do not require google-auth>=2.x.x
-    # Until this issue is closed
-    # https://github.com/googleapis/google-cloud-python/issues/10566
     - google-auth >=1.6.1,<3
     - requests-toolbelt >=0.8.0,<1
     - cloudpickle >=2.0.0,<3
@@ -46,20 +45,20 @@ requirements:
     # kfp-server-api.
     # Note, please also update ./requirements.in
     - kfp-server-api >=1.1.2,<2.0.0
-    - jsonschema >=3.0.1,<4
+    - jsonschema >=3.0.1,<5
     - tabulate >=0.8.6,<1
     - click >=7.1.2,<9
-    - deprecated >=1.2.7,<2
+    - Deprecated >=1.2.7,<2
     - strip-hints >=0.1.8,<1
-    - docstring_parser >=0.7.3,<1
+    - docstring-parser >=0.7.3,<1
     - kfp-pipeline-spec >=0.1.16,<0.2.0
     - fire >=0.3.1,<1
-    #- protobuf >=3.13.0,<4
-    - pydantic >=1.8.2,<2
-    - typing-extensions >=3.7.4,<5
+    - protobuf >=3.13.0,<4
     - uritemplate >=3.0.1,<4
+    # pin to avoid break in requests-toolbelt due to https://github.com/psf/requests/commit/2ad18e0e10e7d7ecd5384c378f25ec8821a10a29
+    - urllib3 <2
+    - pydantic >=1.8.2,<2
     - typer >=0.3.2,<1.0
-    - dataclasses >=0.8,<1
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     # `Blob.from_string` was introduced in google-cloud-storage 1.20.0
     # https://github.com/googleapis/python-storage/blob/master/CHANGELOG.md#1200
     - google-cloud-storage >=1.20.0,<3
-    - kubernetes >=8.0.0,<26
+    - python-kubernetes >=8.0.0,<26
     # google-api-python-client v2 doesnt work for private dicovery by default:
     # https://github.com/googleapis/google-api-python-client/issues/1225#issuecomment-791058235
     - google-api-python-client >=1.7.8,<2
@@ -48,9 +48,9 @@ requirements:
     - jsonschema >=3.0.1,<5
     - tabulate >=0.8.6,<1
     - click >=7.1.2,<9
-    - Deprecated >=1.2.7,<2
+    - deprecated >=1.2.7,<2
     - strip-hints >=0.1.8,<1
-    - docstring-parser >=0.7.3,<1
+    - docstring_parser >=0.7.3,<1
     - kfp-pipeline-spec >=0.1.16,<0.2.0
     - fire >=0.3.1,<1
     - protobuf >=3.13.0,<4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kfp" %}
-{% set version = "1.8.18" %}
+{% set version = "1.8.22" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1f0867d6ce0e1c36a708c0edfc1cfc1ee2f06e60daee4ad4684ee37e645c117d
+  sha256: 3d300cb0f6d5bb303c1197f4d2740f2f27ab1fa6fd6aaa6dd8e72cfa85a72989
 
 build:
   noarch: python


### PR DESCRIPTION
Update kfp to 1.8.22 so that things work with newer dependency versions

Closes https://github.com/conda-forge/kfp-feedstock/pull/89.